### PR TITLE
Changed serial port list to RED.httpAdmin.get (fixes #11)

### DIFF
--- a/src/nodes/vedirect-usb.html
+++ b/src/nodes/vedirect-usb.html
@@ -1,7 +1,5 @@
 <script type="text/javascript">
 
-var portsUrl = (RED.settings.httpNodeRoot || RED.settings.httpAdminRoot || "").replace(/\/$/, "") + '/victron/vedirect-ports/';
-
 function buildEditPanelVVU(node) {
     var buildOption = function buildOption(port) {
         return $('<option/>').val(port.path).text(port.path+' ('+port.manufacturer+': '+port.serialNumber+')').data(port);
@@ -25,14 +23,7 @@ function buildEditPanelVVU(node) {
         selector.append('</optgroup>')
         selector.trigger('change');
     };
-    $.ajax(portsUrl, {
-            beforeSend: function(jqXHR) {
-                var auth_tokens = RED.settings.get("auth-tokens");
-                if (auth_tokens) {
-                    jqXHR.setRequestHeader("Authorization","Bearer "+auth_tokens.access_token);
-                }
-            }
-        })
+    $.getJSON('victron/vedirect-ports')
         .done(data => {
             if (data.length !== 0) {
                 populateSelect($('#node-input-port'), data);

--- a/src/nodes/vedirect-usb.js
+++ b/src/nodes/vedirect-usb.js
@@ -45,13 +45,12 @@ module.exports = function (RED) {
 
   RED.nodes.registerType('victron-vedirect-usb', VEDirectUSB)
 
-  RED.httpNode.get('/victron/vedirect-ports', (req, res) => {
+  RED.httpAdmin.get("/victron/vedirect-ports", RED.auth.needsPermission('serial.read'), function(req,res) {
     SerialPort.list().then((ports) => {
-      res.setHeader('Content-Type', 'application/json')
-      res.send(ports)
+      res.json(ports)
     }, (err) => {
-      console.log(err)
-      res.status(500).send(err)
+      RED.log.error(err)
+      res.status(500).json({ error: err.message })
     })
   })
 }


### PR DESCRIPTION
I was having problems with the serial port list not working (see #11).
I managed to fix it by changing `RED.httpNode.get` to `RED.httpAdmin.get`.

My edit is based on the code in the official serial port node:
https://github.com/node-red/node-red-nodes/blob/master/io/serialport/25-serial.js#L580
